### PR TITLE
feat: added simple RBAC implementation for vendors and test service

### DIFF
--- a/infrastructure/cdk/lib/api-gateway.ts
+++ b/infrastructure/cdk/lib/api-gateway.ts
@@ -1,5 +1,9 @@
 import { Stack, StackProps, App } from '@serverless-stack/resources';
-import { RestApi } from '@aws-cdk/aws-apigateway';
+import {
+  RestApi,
+  GatewayResponse,
+  ResponseType,
+} from '@aws-cdk/aws-apigateway';
 import {
   Certificate,
   CertificateValidation,
@@ -58,6 +62,42 @@ export default class ApiGatewayStack extends Stack {
       },
       deployOptions: {
         stageName: scope.stage,
+      },
+    });
+
+    // Expired Token Gateway Response
+    new GatewayResponse(this, 'ExpiredTokenGatewayResponse', {
+      restApi: api,
+      type: ResponseType.EXPIRED_TOKEN,
+      statusCode: '401',
+      templates: {
+        'application/json': JSON.stringify({
+          message: 'Provided token is expired',
+        }),
+      },
+    });
+
+    // Unauthenticated Gateway Response
+    new GatewayResponse(this, 'UnauthenticatedGatewayResponse', {
+      restApi: api,
+      type: ResponseType.UNAUTHORIZED,
+      statusCode: '401',
+      templates: {
+        'application/json': JSON.stringify({
+          message: '$context.error.message',
+        }),
+      },
+    });
+
+    // Unauthorized Gateway Response
+    new GatewayResponse(this, 'UnauthorizedGatewayResponse', {
+      restApi: api,
+      type: ResponseType.ACCESS_DENIED,
+      statusCode: '403',
+      templates: {
+        'application/json': JSON.stringify({
+          message: '$context.authorizer.errorMessage',
+        }),
       },
     });
 

--- a/libs/auth/jest.config.js
+++ b/libs/auth/jest.config.js
@@ -1,0 +1,8 @@
+const base = require('../../build/jest.config.js');
+const package = require('./package.json');
+
+module.exports = {
+  ...base,
+  name: package.name,
+  displayName: package.name,
+};

--- a/libs/auth/package.json
+++ b/libs/auth/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@townhub-libs/auth",
+  "version": "0.0.0",
+  "main": "dist/index",
+  "module": "dist/index.es",
+  "types": "dist/index.d.ts",
+  "private": true,
+  "dependencies": {
+  },
+  "devDependencies": {
+  },
+  "scripts": {
+    "build": "rollup -c ./rollup.config.js",
+    "test": "jest"
+  }
+}

--- a/libs/auth/rollup.config.js
+++ b/libs/auth/rollup.config.js
@@ -1,0 +1,16 @@
+import config from '../../build/rollup.config';
+
+export default {
+  ...config,
+  input: 'src/index.ts',
+  output: [
+    {
+      file: 'dist/index.es.js',
+      format: 'es',
+    },
+    {
+      file: 'dist/index.js',
+      format: 'commonjs',
+    },
+  ],
+};

--- a/libs/auth/src/base.spec.ts
+++ b/libs/auth/src/base.spec.ts
@@ -2,7 +2,7 @@ import { generatePermission } from './base';
 
 describe('Base Helpers', () => {
   describe('generatePermissions', () => {
-    it('generates all permissions by default', () => {
+    it('generates own permissions by default', () => {
       expect(generatePermission('vendors', 'create')).toEqual(
         'vendors:create:own'
       );

--- a/libs/auth/src/base.spec.ts
+++ b/libs/auth/src/base.spec.ts
@@ -1,0 +1,16 @@
+import { generatePermission } from './base';
+
+describe('Base Helpers', () => {
+  describe('generatePermissions', () => {
+    it('generates all permissions by default', () => {
+      expect(generatePermission('vendors', 'create')).toEqual(
+        'vendors:create:all'
+      );
+    });
+    it('generates the correct permissions provided', () => {
+      expect(generatePermission('vendors', 'update', 'own')).toEqual(
+        'vendors:update:own'
+      );
+    });
+  });
+});

--- a/libs/auth/src/base.spec.ts
+++ b/libs/auth/src/base.spec.ts
@@ -4,12 +4,12 @@ describe('Base Helpers', () => {
   describe('generatePermissions', () => {
     it('generates all permissions by default', () => {
       expect(generatePermission('vendors', 'create')).toEqual(
-        'vendors:create:all'
+        'vendors:create:own'
       );
     });
     it('generates the correct permissions provided', () => {
-      expect(generatePermission('vendors', 'update', 'own')).toEqual(
-        'vendors:update:own'
+      expect(generatePermission('vendors', 'update', 'all')).toEqual(
+        'vendors:update:all'
       );
     });
   });

--- a/libs/auth/src/base.ts
+++ b/libs/auth/src/base.ts
@@ -14,5 +14,5 @@ export type Ownership = 'all' | 'own';
 export const generatePermission = (
   namespace: Namespace,
   action: Action,
-  ownership: Ownership = 'all'
+  ownership: Ownership = 'own'
 ) => `${namespace}:${action}:${ownership}`;

--- a/libs/auth/src/base.ts
+++ b/libs/auth/src/base.ts
@@ -1,0 +1,18 @@
+export const ROLES = {
+  USER: 'user' as const,
+  PUBLIC: 'public' as const,
+};
+export type UserRole = typeof ROLES.USER | typeof ROLES.PUBLIC;
+
+export const VENDORS = 'vendors';
+export const TEST = 'test/auth';
+
+export type Namespace = typeof VENDORS | typeof TEST;
+export type Action = 'create' | 'read' | 'update' | 'delete';
+export type Ownership = 'all' | 'own';
+
+export const generatePermission = (
+  namespace: Namespace,
+  action: Action,
+  ownership: Ownership = 'all'
+) => `${namespace}:${action}:${ownership}`;

--- a/libs/auth/src/index.spec.ts
+++ b/libs/auth/src/index.spec.ts
@@ -1,0 +1,44 @@
+import { Namespace } from './base';
+import { filterPermissionsForAction, getPermissionsForRoles } from './index';
+
+describe('Auth helpers', () => {
+  describe('getPermissionsForRoles', () => {
+    it('returns the correct uniq list', () => {
+      expect(getPermissionsForRoles(['public'])).toEqual(['vendors:read:all']);
+      expect(getPermissionsForRoles(['user'])).toEqual([
+        'vendors:read:all',
+        'vendors:create:all',
+        'vendors:update:own',
+        'vendors:delete:own',
+      ]);
+    });
+  });
+  describe('filterPermissionsForAction', () => {
+    it('returns the correct list of permissions', () => {
+      const permissionList = [
+        'vendors:read:all',
+        'vendors:create:all',
+        'vendors:update:own',
+        'vendors:delete:own',
+        'other:create:own',
+        'other:create:all',
+      ];
+      expect(
+        filterPermissionsForAction(permissionList, 'vendors', 'create')
+      ).toEqual(['vendors:create:all']);
+      expect(filterPermissionsForAction(permissionList, 'vendors')).toEqual([
+        'vendors:read:all',
+        'vendors:create:all',
+        'vendors:update:own',
+        'vendors:delete:own',
+      ]);
+      expect(
+        filterPermissionsForAction(
+          permissionList,
+          'other' as Namespace,
+          'create'
+        )
+      ).toEqual(['other:create:own', 'other:create:all']);
+    });
+  });
+});

--- a/libs/auth/src/index.spec.ts
+++ b/libs/auth/src/index.spec.ts
@@ -10,6 +10,7 @@ describe('Auth helpers', () => {
         'vendors:create:all',
         'vendors:update:own',
         'vendors:delete:own',
+        'test/auth:read:all'
       ]);
     });
   });

--- a/libs/auth/src/index.ts
+++ b/libs/auth/src/index.ts
@@ -1,7 +1,7 @@
 import uniq from 'lodash.uniq';
 import { Action, Namespace, UserRole } from './base';
 import { VENDORS_PERMISSIONS } from './vendors';
-import { TESTS_PERMISSIONS } from './test';
+import { TESTS_PERMISSIONS } from './test-service';
 
 /**
  * Get the full list of permissions given a set of roles

--- a/libs/auth/src/index.ts
+++ b/libs/auth/src/index.ts
@@ -1,0 +1,38 @@
+import uniq from 'lodash.uniq';
+import { Action, Namespace, UserRole } from './base';
+import { VENDORS_PERMISSIONS } from './vendors';
+import { TESTS_PERMISSIONS } from './test';
+
+/**
+ * Get the full list of permissions given a set of roles
+ * @param roles The roles the user has
+ */
+export const getPermissionsForRoles = (roles: UserRole[]): string[] => {
+  const list: string[] = [];
+  roles.forEach((role) => {
+    // Set the vendors permissions
+    list.push(...VENDORS_PERMISSIONS[role]);
+    list.push(...TESTS_PERMISSIONS[role]);
+  });
+  return uniq(list);
+};
+
+/**
+ * Filter a list of permissions based on a provided namespace and action
+ *
+ * This allows us to check whether or not a user can perform certain actions
+ * @param permissionList The list of permissions a user has
+ * @param namespace The namespace to check for
+ * @param action The action to check for
+ */
+export const filterPermissionsForAction = (
+  permissionList: string[],
+  namespace: Namespace,
+  action?: Action
+): string[] => {
+  return permissionList.filter((val) =>
+    val.startsWith(`${namespace}:${action || ''}`)
+  );
+};
+
+export { UserRole, Namespace, Action };

--- a/libs/auth/src/test-service.ts
+++ b/libs/auth/src/test-service.ts
@@ -1,7 +1,11 @@
+/** 
+ * Had to name it test-service.ts as test.ts triggers jest to think that this
+ * is a test
+ */
 import { generatePermission, ROLES, TEST } from './base';
 
 export const TESTS_AVAILABLE_PERMISSIONS = {
-  auth: generatePermission(TEST, 'read'),
+  auth: generatePermission(TEST, 'read', 'all'),
 };
 
 export const TESTS_PERMISSIONS = {

--- a/libs/auth/src/test.ts
+++ b/libs/auth/src/test.ts
@@ -1,0 +1,10 @@
+import { generatePermission, ROLES, TEST } from './base';
+
+export const TESTS_AVAILABLE_PERMISSIONS = {
+  auth: generatePermission(TEST, 'read'),
+};
+
+export const TESTS_PERMISSIONS = {
+  [ROLES.PUBLIC]: [],
+  [ROLES.USER]: [TESTS_AVAILABLE_PERMISSIONS.auth],
+};

--- a/libs/auth/src/vendors.ts
+++ b/libs/auth/src/vendors.ts
@@ -1,0 +1,18 @@
+import { generatePermission, ROLES, VENDORS } from './base';
+
+export const VENDORS_AVAILABLE_PERMISSIONS = {
+  create: generatePermission(VENDORS, 'create'),
+  read: generatePermission(VENDORS, 'read'),
+  update: generatePermission(VENDORS, 'update', 'own'),
+  delete: generatePermission(VENDORS, 'delete', 'own'),
+};
+
+export const VENDORS_PERMISSIONS = {
+  [ROLES.PUBLIC]: [VENDORS_AVAILABLE_PERMISSIONS.read],
+  [ROLES.USER]: [
+    VENDORS_AVAILABLE_PERMISSIONS.read,
+    VENDORS_AVAILABLE_PERMISSIONS.create,
+    VENDORS_AVAILABLE_PERMISSIONS.update,
+    VENDORS_AVAILABLE_PERMISSIONS.delete,
+  ],
+};

--- a/libs/auth/src/vendors.ts
+++ b/libs/auth/src/vendors.ts
@@ -1,10 +1,10 @@
 import { generatePermission, ROLES, VENDORS } from './base';
 
 export const VENDORS_AVAILABLE_PERMISSIONS = {
-  create: generatePermission(VENDORS, 'create'),
-  read: generatePermission(VENDORS, 'read'),
-  update: generatePermission(VENDORS, 'update', 'own'),
-  delete: generatePermission(VENDORS, 'delete', 'own'),
+  create: generatePermission(VENDORS, 'create', 'all'),
+  read: generatePermission(VENDORS, 'read', 'all'),
+  update: generatePermission(VENDORS, 'update'),
+  delete: generatePermission(VENDORS, 'delete'),
 };
 
 export const VENDORS_PERMISSIONS = {

--- a/libs/auth/tsconfig.build.json
+++ b/libs/auth/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src"]
+}

--- a/libs/auth/tsconfig.build.json
+++ b/libs/auth/tsconfig.build.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "."
+  },
   "include": ["src"]
 }

--- a/libs/core/src/wrappers/api-gateway.ts
+++ b/libs/core/src/wrappers/api-gateway.ts
@@ -1,5 +1,5 @@
 import * as Sentry from '@sentry/node';
-import { UserRole } from '@townhub-libs/auth/base';
+import { UserRole } from '@townhub-libs/auth';
 import {
   APIGatewayProxyWithLambdaAuthorizerEvent,
   APIGatewayProxyWithLambdaAuthorizerHandler,

--- a/libs/core/tsconfig.build.json
+++ b/libs/core/tsconfig.build.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "."
+  },
   "include": ["src"]
 }

--- a/services/auth/package.json
+++ b/services/auth/package.json
@@ -7,6 +7,7 @@
     "@types/jsonwebtoken": "^8.5.0"
   },
   "dependencies": {
+    "@townhub-libs/auth": "^0.0.0",
     "jsonwebtoken": "^8.5.1",
     "jwks-rsa": "^1.12.1"
   },

--- a/services/auth/src/authenticate.ts
+++ b/services/auth/src/authenticate.ts
@@ -1,6 +1,7 @@
 import { APIGatewayTokenAuthorizerEvent } from 'aws-lambda';
 import jwksClient from 'jwks-rsa';
 import { decode, verify } from 'jsonwebtoken';
+import { UserRole } from '@townhub-libs/auth';
 
 // Initialize JWKS Client
 const Client = jwksClient({
@@ -46,6 +47,7 @@ export const getSigningKey = async (kid: string) => {
  * The decoded token should have these details in the payload
  */
 export interface DecodedTokenPayload {
+  'https://townhub.ca/profile': { roles: UserRole[] },
   sub: string;
   aud: string;
   iat: number;

--- a/services/auth/src/authenticate.ts
+++ b/services/auth/src/authenticate.ts
@@ -73,7 +73,6 @@ interface DecodedToken {
  * @param signingKey The signing key to use to check it
  */
 export const verifyToken = (token: string, signingKey: string) => {
-  // TODO: change to use async, and convert to promises
   return verify(token, signingKey, {
     audience: process.env.AUTH0_AUDIENCE || '',
     issuer: process.env.AUTH0_ISSUER || '',

--- a/services/auth/src/policy.ts
+++ b/services/auth/src/policy.ts
@@ -7,7 +7,7 @@ import { PolicyDocument } from 'aws-lambda';
  * @param resource The resource to call
  */
 export const generatePolicyDocument = (
-  effect: 'Allow' | 'Deny',
+  allow: boolean,
   resource: string
 ): PolicyDocument => {
   return {
@@ -15,7 +15,7 @@ export const generatePolicyDocument = (
     Statement: [
       {
         Action: 'execute-api:Invoke', // default action
-        Effect: effect,
+        Effect: allow ? 'Allow' : 'Deny',
         Resource: resource,
       },
     ],

--- a/services/auth/src/token-authorizer.ts
+++ b/services/auth/src/token-authorizer.ts
@@ -1,19 +1,51 @@
 import { APIGatewayTokenAuthorizerEvent } from 'aws-lambda';
+import {
+  filterPermissionsForAction,
+  getPermissionsForRoles,
+  Namespace,
+} from '@townhub-libs/auth';
 import { authenticate } from './authenticate';
 import { generatePolicyDocument } from './policy';
 
-export const main = async (
-  event: APIGatewayTokenAuthorizerEvent
-) => {
+/**
+ * Breakdown the methodArn into something we can understand easier
+ * @param methodArn The method arn to breakdown
+ */
+const breakdownMethodArn = (methodArn: string) => {
+  const [arn, stage, method, ...path] = methodArn.split('/');
+  const fullPath = path.join('/');
+  const namespace = fullPath.split('/:')[0];
+  return {
+    arn,
+    stage,
+    method,
+    namespace: namespace as Namespace,
+    path: fullPath,
+  };
+};
+
+export const main = async (event: APIGatewayTokenAuthorizerEvent) => {
   try {
+    const arnBreakdown = breakdownMethodArn(event.methodArn);
+
     const decodedToken = await authenticate(event);
-    console.log(decodedToken);
+    const roles = decodedToken['https://townhub.ca/profile'].roles;
+
+    const permissionList = filterPermissionsForAction(
+      getPermissionsForRoles(roles),
+      arnBreakdown.namespace
+    );
+  
     return {
       principalId: decodedToken.sub,
-      policyDocument: generatePolicyDocument('Allow', event.methodArn),
-      // TODO: When we implement RBAC, we should update the scopes provided here
-      context: { scope: 'test' }
-    }
+      policyDocument: generatePolicyDocument(
+        permissionList.length > 0,
+        event.methodArn
+      ),
+      // Pass the list of permissions as context to the function handler
+      // TODO: pass the userId, etc.
+      context: { permissions: JSON.stringify(permissionList) },
+    };
   } catch (err) {
     console.log('err', err);
     return Promise.reject((err as Error).message);

--- a/services/test/src/another.ts
+++ b/services/test/src/another.ts
@@ -4,11 +4,12 @@ import { ApiGatewayWrapper } from '@townhub-libs/core';
  * Here is some test documentation for this function yay
  * @param event
  */
-export const main = ApiGatewayWrapper(async (event, context) => {
+export const main = ApiGatewayWrapper(async (details, event, context) => {
   return {
     statusCode: 200,
     message: 'Go Serverless v1.20! Your function executed successfully!',
     data: {
+      details,
       event,
       context
     },

--- a/services/test/src/another.ts
+++ b/services/test/src/another.ts
@@ -4,10 +4,13 @@ import { ApiGatewayWrapper } from '@townhub-libs/core';
  * Here is some test documentation for this function yay
  * @param event
  */
-export const main = ApiGatewayWrapper(async () => {
+export const main = ApiGatewayWrapper(async (event, context) => {
   return {
     statusCode: 200,
     message: 'Go Serverless v1.20! Your function executed successfully!',
-    data: `should have no other imports except for`,
+    data: {
+      event,
+      context
+    },
   };
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,8 @@
     // Paths to shared libraries
     "baseUrl": ".",
     "paths": {
+      "@townhub-libs/auth": ["libs/auth/src"],
+      "@townhub-libs/auth/*": ["libs/auth/src/*"],
       "@townhub-libs/core": ["libs/core/src"],
       "@townhub-libs/core/*": ["libs/core/src/*"],
       "@townhub-libs/shuttles": ["libs/shuttles/src"],


### PR DESCRIPTION
Since Auth0 requires a paid account for roles and permissions, we just create this simple RBAC implementation so we can have a basic roles and permissions system until we have enough users to warrant paying for Auth0 and using their roles and permissions.