### PR TITLE
feat(transit): added the transit library as a GTFS replacement for shuttles

### DIFF
--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -1,0 +1,7 @@
+# Naming Conventions
+
+| Description                | Case       | Example       |
+| -------------------------- | ---------- | ------------- |
+| Database field             | snake_case | created_at    |
+| TypeScript Interface/Types | PascalCase | BaseEntity    |
+| Classes                    | PascalCase | UsersDatabase |

--- a/docs/dynamodb.md
+++ b/docs/dynamodb.md
@@ -1,0 +1,9 @@
+# DynamoDB
+
+## Condition Expression
+
+The condition expression is useful in stopping duplication and mistaken writes.
+
+Resources:
+
+- https://www.alexdebrie.com/posts/dynamodb-condition-expressions/

--- a/libs/core/src/base/database.ts
+++ b/libs/core/src/base/database.ts
@@ -24,15 +24,22 @@ const ddb = {
 export type BaseEntity = {
   id: string;
   /** The time this entity was created */
-  createdAt: number;
+  created_at: number;
   /** The time this entity was updated */
-  updatedAt: number;
+  updated_at: number;
+  /**
+   * The time this entity was created
+   * @deprecated
+   */
+  createdAt?: number;
+  /**
+   * The time this entity was updated
+   * @deprecated
+   */
+  updatedAt?: number;
 };
 
-export type OmitAuditFields<TItem> = Omit<
-  TItem,
-  'createdAt' | 'updatedAt' | 'assignedAt'
->;
+export type OmitAuditFields<TItem> = Omit<TItem, 'created_at' | 'updated_at'>;
 export type OmitId<TItem> = Omit<TItem, 'id'>;
 
 export type DatabaseCreateInput<TItem> = OmitAuditFields<OmitId<TItem>>;
@@ -82,9 +89,12 @@ export class Database<TItem extends BaseEntity = any> {
    * @param item The item to place in
    */
   async create(item: DatabaseCreateInput<TItem>) {
-    const newItem: any = {
+    const newItem: BaseEntity = {
       id: uuidv4(),
       ...item,
+      created_at: new Date().valueOf(),
+      updated_at: new Date().valueOf(),
+      // TODO: Remove the below once we are happy it has been removed
       createdAt: new Date().valueOf(),
       updatedAt: new Date().valueOf(),
     };
@@ -108,6 +118,8 @@ export class Database<TItem extends BaseEntity = any> {
     const newItem = {
       ...oldItem,
       ...item,
+      updated_at: new Date().valueOf(),
+      // TODO: remove once all is deprecated
       updatedAt: new Date().valueOf(),
     };
 
@@ -161,7 +173,9 @@ export class Database<TItem extends BaseEntity = any> {
 
       return (data.Responses?.[this.tableName] as TItem[]) ?? [];
     } catch (error) {
-      throw new NotFoundException(error.message || 'Unable to find items');
+      throw new NotFoundException(
+        (error as Error).message || 'Unable to find items'
+      );
     }
   }
 

--- a/libs/shuttles/src/daily-data/helpers.spec.ts
+++ b/libs/shuttles/src/daily-data/helpers.spec.ts
@@ -189,32 +189,32 @@ describe('shuttle helpers', () => {
         id: 'stop-1',
         townId: 'town-1',
         name: 'Stop 1',
-        createdAt: 0,
-        updatedAt: 0,
+        created_at: 0,
+        updated_at: 0,
         point: { lat: 0, lng: 0 },
       },
       {
         id: 'stop-2',
         townId: 'town-1',
         name: 'Stop 2',
-        createdAt: 0,
-        updatedAt: 0,
+        created_at: 0,
+        updated_at: 0,
         point: { lat: 0, lng: 0 },
       },
       {
         id: 'stop-3',
         townId: 'town-1',
         name: 'Stop 3',
-        createdAt: 0,
-        updatedAt: 0,
+        created_at: 0,
+        updated_at: 0,
         point: { lat: 0, lng: 0 },
       },
       {
         id: 'stop-4',
         townId: 'town-1',
         name: 'Stop 4',
-        createdAt: 0,
-        updatedAt: 0,
+        created_at: 0,
+        updated_at: 0,
         point: { lat: 0, lng: 0 },
       },
     ];
@@ -234,8 +234,8 @@ describe('shuttle helpers', () => {
           id: 'stop-1',
           townId: 'town-1',
           name: 'Stop 1',
-          createdAt: 0,
-          updatedAt: 0,
+          created_at: 0,
+          updated_at: 0,
           scheduleDate: timestamp.toFormat(DEFAULT_DATE_FORMAT),
           routes: [
             {
@@ -251,8 +251,8 @@ describe('shuttle helpers', () => {
           id: 'stop-2',
           townId: 'town-1',
           name: 'Stop 2',
-          createdAt: 0,
-          updatedAt: 0,
+          created_at: 0,
+          updated_at: 0,
           scheduleDate: timestamp.toFormat(DEFAULT_DATE_FORMAT),
           routes: [
             {
@@ -268,8 +268,8 @@ describe('shuttle helpers', () => {
           id: 'stop-3',
           townId: 'town-1',
           name: 'Stop 3',
-          createdAt: 0,
-          updatedAt: 0,
+          created_at: 0,
+          updated_at: 0,
           scheduleDate: timestamp.toFormat(DEFAULT_DATE_FORMAT),
           routes: [
             {
@@ -285,8 +285,8 @@ describe('shuttle helpers', () => {
           id: 'stop-4',
           townId: 'town-1',
           name: 'Stop 4',
-          createdAt: 0,
-          updatedAt: 0,
+          created_at: 0,
+          updated_at: 0,
           scheduleDate: timestamp.toFormat(DEFAULT_DATE_FORMAT),
           routes: [
             {
@@ -336,8 +336,8 @@ describe('shuttle helpers', () => {
           id: 'stop-1',
           townId: 'town-1',
           name: 'Stop 1',
-          createdAt: 0,
-          updatedAt: 0,
+          created_at: 0,
+          updated_at: 0,
           scheduleDate: timestamp.toFormat(DEFAULT_DATE_FORMAT),
           routes: [
             {
@@ -353,8 +353,8 @@ describe('shuttle helpers', () => {
           id: 'stop-3',
           townId: 'town-1',
           name: 'Stop 3',
-          createdAt: 0,
-          updatedAt: 0,
+          created_at: 0,
+          updated_at: 0,
           scheduleDate: timestamp.toFormat(DEFAULT_DATE_FORMAT),
           routes: [
             {
@@ -377,7 +377,7 @@ describe('shuttle helpers', () => {
 
   describe('convertRoutesToDailyDataRoutes', () => {
     const route: Route = {
-      createdAt: 1604903727734,
+      created_at: 1604903727734,
       stopList: [
         {
           stopId: 'stop-1',
@@ -392,23 +392,23 @@ describe('shuttle helpers', () => {
       description: 'The morning route',
       townId: '1eefd261-6b35-4f2a-8e44-fffec17b2f1a',
       id: '60ec0346-8f98-4451-9571-6a9ff17430c9',
-      updatedAt: 1604903727734,
+      updated_at: 1604903727734,
     };
     const stops: Stop[] = [
       {
         id: 'stop-1',
         townId: 'town-1',
         name: 'Stop 1',
-        createdAt: 0,
-        updatedAt: 0,
+        created_at: 0,
+        updated_at: 0,
         point: { lat: 0, lng: 0 },
       },
       {
         id: 'stop-2',
         townId: 'town-1',
         name: 'Stop 2',
-        createdAt: 0,
-        updatedAt: 0,
+        created_at: 0,
+        updated_at: 0,
         point: { lat: 1, lng: 1 },
       },
     ];

--- a/libs/shuttles/src/daily-data/helpers.spec.ts
+++ b/libs/shuttles/src/daily-data/helpers.spec.ts
@@ -190,7 +190,9 @@ describe('shuttle helpers', () => {
         townId: 'town-1',
         name: 'Stop 1',
         created_at: 0,
+        created_by: 'system',
         updated_at: 0,
+        updated_by: 'system',
         point: { lat: 0, lng: 0 },
       },
       {
@@ -198,7 +200,9 @@ describe('shuttle helpers', () => {
         townId: 'town-1',
         name: 'Stop 2',
         created_at: 0,
+        created_by: 'system',
         updated_at: 0,
+        updated_by: 'system',
         point: { lat: 0, lng: 0 },
       },
       {
@@ -206,7 +210,9 @@ describe('shuttle helpers', () => {
         townId: 'town-1',
         name: 'Stop 3',
         created_at: 0,
+        created_by: 'system',
         updated_at: 0,
+        updated_by: 'system',
         point: { lat: 0, lng: 0 },
       },
       {
@@ -214,7 +220,9 @@ describe('shuttle helpers', () => {
         townId: 'town-1',
         name: 'Stop 4',
         created_at: 0,
+        created_by: 'system',
         updated_at: 0,
+        updated_by: 'system',
         point: { lat: 0, lng: 0 },
       },
     ];
@@ -235,7 +243,9 @@ describe('shuttle helpers', () => {
           townId: 'town-1',
           name: 'Stop 1',
           created_at: 0,
+          created_by: 'system',
           updated_at: 0,
+          updated_by: 'system',
           scheduleDate: timestamp.toFormat(DEFAULT_DATE_FORMAT),
           routes: [
             {
@@ -252,7 +262,9 @@ describe('shuttle helpers', () => {
           townId: 'town-1',
           name: 'Stop 2',
           created_at: 0,
+          created_by: 'system',
           updated_at: 0,
+          updated_by: 'system',
           scheduleDate: timestamp.toFormat(DEFAULT_DATE_FORMAT),
           routes: [
             {
@@ -269,7 +281,9 @@ describe('shuttle helpers', () => {
           townId: 'town-1',
           name: 'Stop 3',
           created_at: 0,
+          created_by: 'system',
           updated_at: 0,
+          updated_by: 'system',
           scheduleDate: timestamp.toFormat(DEFAULT_DATE_FORMAT),
           routes: [
             {
@@ -286,7 +300,9 @@ describe('shuttle helpers', () => {
           townId: 'town-1',
           name: 'Stop 4',
           created_at: 0,
+          created_by: 'system',
           updated_at: 0,
+          updated_by: 'system',
           scheduleDate: timestamp.toFormat(DEFAULT_DATE_FORMAT),
           routes: [
             {
@@ -337,7 +353,9 @@ describe('shuttle helpers', () => {
           townId: 'town-1',
           name: 'Stop 1',
           created_at: 0,
+          created_by: 'system',
           updated_at: 0,
+          updated_by: 'system',
           scheduleDate: timestamp.toFormat(DEFAULT_DATE_FORMAT),
           routes: [
             {
@@ -354,7 +372,9 @@ describe('shuttle helpers', () => {
           townId: 'town-1',
           name: 'Stop 3',
           created_at: 0,
+          created_by: 'system',
           updated_at: 0,
+          updated_by: 'system',
           scheduleDate: timestamp.toFormat(DEFAULT_DATE_FORMAT),
           routes: [
             {
@@ -378,6 +398,7 @@ describe('shuttle helpers', () => {
   describe('convertRoutesToDailyDataRoutes', () => {
     const route: Route = {
       created_at: 1604903727734,
+      created_by: 'system',
       stopList: [
         {
           stopId: 'stop-1',
@@ -393,6 +414,7 @@ describe('shuttle helpers', () => {
       townId: '1eefd261-6b35-4f2a-8e44-fffec17b2f1a',
       id: '60ec0346-8f98-4451-9571-6a9ff17430c9',
       updated_at: 1604903727734,
+      updated_by: 'system',
     };
     const stops: Stop[] = [
       {
@@ -400,7 +422,9 @@ describe('shuttle helpers', () => {
         townId: 'town-1',
         name: 'Stop 1',
         created_at: 0,
+        created_by: 'system',
         updated_at: 0,
+        updated_by: 'system',
         point: { lat: 0, lng: 0 },
       },
       {
@@ -408,7 +432,9 @@ describe('shuttle helpers', () => {
         townId: 'town-1',
         name: 'Stop 2',
         created_at: 0,
+        created_by: 'system',
         updated_at: 0,
+        updated_by: 'system',
         point: { lat: 1, lng: 1 },
       },
     ];

--- a/libs/shuttles/src/daily-data/index.ts
+++ b/libs/shuttles/src/daily-data/index.ts
@@ -18,11 +18,13 @@ import {
  * @param townId The town to check
  * @param timestamp The timestamp to signify which day it is
  * @param timezone The timezone we are performing the calculations on
+ * @param actorId The user requesting the daily data
  */
 export const getDailyData = async (
   townId: string,
   timestamp: number,
-  timezone: string = DEFAULT_TIMEZONE
+  timezone: string = DEFAULT_TIMEZONE,
+  actorId: string = 'public'
 ) => {
   const DailySchedules = new DailySchedulesDatabase();
   const Schedules = new SchedulesDatabase();
@@ -68,13 +70,16 @@ export const getDailyData = async (
     middleOfDay
   );
 
-  const newDailySchedule = await DailySchedules.create({
-    townId,
-    timestamp: dateString,
-    stops: stopSchedules,
-    schedules,
-    routes: dailyDataRoutes,
-  });
+  const newDailySchedule = await DailySchedules.create(
+    {
+      townId,
+      timestamp: dateString,
+      stops: stopSchedules,
+      schedules,
+      routes: dailyDataRoutes,
+    },
+    actorId
+  );
 
   return newDailySchedule;
 };

--- a/libs/towns/src/database.ts
+++ b/libs/towns/src/database.ts
@@ -19,8 +19,9 @@ export class TownsDatabase extends Database<Town> {
   /**
    * Create a new town. Must have a unique Human Readable ID
    * @param item The town to create
+   * @param actorId The user creating the town
    */
-  async create(item: DatabaseCreateInput<Town>) {
+  async create(item: DatabaseCreateInput<Town>, actorId: string) {
     try {
       const existingTown = await this.getByHid(item.hid);
       if (existingTown)
@@ -34,7 +35,7 @@ export class TownsDatabase extends Database<Town> {
     }
 
     // We are here, so must be able to continue
-    return super.create(item);
+    return super.create(item, actorId);
   }
 
   /**

--- a/libs/transit/jest.config.js
+++ b/libs/transit/jest.config.js
@@ -1,0 +1,8 @@
+const base = require('../../build/jest.config.js');
+const package = require('./package.json');
+
+module.exports = {
+  ...base,
+  name: package.name,
+  displayName: package.name,
+};

--- a/libs/transit/package.json
+++ b/libs/transit/package.json
@@ -10,6 +10,7 @@
   },
   "devDependencies": {},
   "scripts": {
+    "build:dependencies": "lerna run build --scope @townhub-libs/transit --include-dependencies --",
     "build": "rollup -c ./rollup.config.js",
     "test": "jest"
   }

--- a/libs/transit/package.json
+++ b/libs/transit/package.json
@@ -12,6 +12,6 @@
   "scripts": {
     "build:dependencies": "lerna run build --scope @townhub-libs/transit --include-dependencies --",
     "build": "rollup -c ./rollup.config.js",
-    "test": "jest"
+    "test": "jest --passWithNoTests"
   }
 }

--- a/libs/transit/package.json
+++ b/libs/transit/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@townhub-libs/transit",
+  "version": "0.0.0",
+  "main": "dist/index",
+  "module": "dist/index.es",
+  "types": "dist/index.d.ts",
+  "private": true,
+  "dependencies": {
+    "@townhub-libs/core": "^0.0.0"
+  },
+  "devDependencies": {},
+  "scripts": {
+    "build": "rollup -c ./rollup.config.js",
+    "test": "jest"
+  }
+}

--- a/libs/transit/rollup.config.js
+++ b/libs/transit/rollup.config.js
@@ -1,0 +1,16 @@
+import config from '../../build/rollup.config';
+
+export default {
+  ...config,
+  input: 'src/index.ts',
+  output: [
+    {
+      file: 'dist/index.es.js',
+      format: 'es',
+    },
+    {
+      file: 'dist/index.js',
+      format: 'commonjs',
+    },
+  ],
+};

--- a/libs/transit/src/agencies/database.ts
+++ b/libs/transit/src/agencies/database.ts
@@ -1,0 +1,9 @@
+import { Database } from '@townhub-libs/core';
+import { TransitDatabaseEnv } from '../constants';
+import { Agency } from './interfaces';
+
+export class AgenciesDatabase extends Database<Agency> {
+  constructor() {
+    super(TransitDatabaseEnv.Agencies);
+  }
+}

--- a/libs/transit/src/agencies/index.ts
+++ b/libs/transit/src/agencies/index.ts
@@ -1,0 +1,2 @@
+export * from './database';
+export * from './interfaces';

--- a/libs/transit/src/agencies/interfaces.ts
+++ b/libs/transit/src/agencies/interfaces.ts
@@ -1,0 +1,47 @@
+import { BaseEntity } from '@townhub-libs/core';
+import { Email, LanguageCode, PhoneNumber, Timezone, URL } from '../interfaces';
+
+/**
+ * Identifies a transit brand which is often synonymous with a transit agency.
+ * Note that in some cases, such as when a single agency operates multiple
+ * separate services, agencies and brands are distinct. This document uses the
+ * term "agency" in place of "brand".
+ */
+export interface Agency extends BaseEntity {
+  /** Full name of the transit agency. */
+  name: string;
+  /**
+   * URL of the transit agency.
+   */
+  url: URL;
+  /**
+   * Timezone where the transit agency is located. If multiple agencies are
+   * specified in the dataset, each must have the same timezone.
+   */
+  timezone: Timezone;
+  /**
+   * Primary language used by this transit agency. This field helps GTFS
+   * consumers choose capitalization rules and other language-specific settings
+   * for the dataset.
+   */
+  lang?: LanguageCode;
+  /**
+   * A voice telephone number for the specified agency. This field is a string
+   * value that presents the telephone number as typical for the agency's
+   * service area. It can and should contain punctuation marks to group the
+   * digits of the number. Dialable text (for example, TriMet's "503-238-RIDE")
+   * is permitted, but the field must not contain any other descriptive text.
+   */
+  phone?: PhoneNumber;
+  /**
+   * URL of a web page that allows a rider to purchase tickets or other fare
+   * instruments for that agency online.
+   */
+  fare_url?: URL;
+  /**
+   * Email address actively monitored by the agency’s customer service
+   * department. This email address should be a direct contact point where
+   * transit riders can reach a customer service representative at the agency.
+   */
+  email?: Email;
+}

--- a/libs/transit/src/constants.ts
+++ b/libs/transit/src/constants.ts
@@ -1,0 +1,8 @@
+export enum TransitDatabaseEnv {
+  Agencies = 'AGENCIES_TABLE_NAME',
+  DailyData = 'DAILY_DATA_TABLE_NAME',
+  Routes = 'ROUTES_TABLE_NAME',
+  Services = 'SERVICES_TABLE_NAME',
+  Stops = 'STOPS_TABLE_NAME',
+  Trips = 'TRIPS_TABLE_NAME',
+}

--- a/libs/transit/src/constants.ts
+++ b/libs/transit/src/constants.ts
@@ -11,9 +11,9 @@ export const DDB_INDEX_NAMES = {
   SERVICES: {
     /**
      * * PartitionKey: agency_id
-     * * SortKey:      start_date
+     * * SortKey:      end_date
      */
-    AGENCY_ID_START_DATE: 'agency_id-start_date-index',
+    AGENCY_ID_END_DATE: 'agency_id-end_date-index',
   },
   TRIPS: {
     /**

--- a/libs/transit/src/constants.ts
+++ b/libs/transit/src/constants.ts
@@ -6,3 +6,20 @@ export enum TransitDatabaseEnv {
   Stops = 'STOPS_TABLE_NAME',
   Trips = 'TRIPS_TABLE_NAME',
 }
+
+export const DDB_INDEX_NAMES = {
+  SERVICES: {
+    /**
+     * * PartitionKey: agency_id
+     * * SortKey:      start_date
+     */
+    AGENCY_ID_START_DATE: 'agency_id-start_date-index',
+  },
+  TRIPS: {
+    /**
+     * * PartitionKey: agency_id
+     * * SortKey:      service_id
+     */
+    AGENCY_ID_SERVICE_ID: 'agency_id-service_id-index',
+  },
+};

--- a/libs/transit/src/daily-data/database.ts
+++ b/libs/transit/src/daily-data/database.ts
@@ -1,9 +1,41 @@
-import { Database } from '@townhub-libs/core';
+import { Database, DatabaseCreateInput } from '@townhub-libs/core';
 import { TransitDatabaseEnv } from '../constants';
 import { DailyTransitData } from './interfaces';
 
+/**
+ * The Daily Data Table should be setup with the following details:
+ * * PartitionKey: `agency_id`
+ * * SortKey:      `date`
+ *
+ * This will allow us to make sure that the agency_id|date combination is
+ * unique in the database. As we should be generating a single item for each
+ * day's worth of data.
+ */
 export class DailyDataDatabase extends Database<DailyTransitData> {
   constructor() {
     super(TransitDatabaseEnv.DailyData);
+  }
+
+  /**
+   * When creating a daily data, we want to make sure that the particular
+   * agency_id and date combination does not already exist in the database
+   * @param item The new dailyData to create
+   * @param actorId The user performing the create
+   * @returns The dailydata that was created
+   */
+  async create(
+    item: DatabaseCreateInput<DailyTransitData>,
+    actorId: string
+  ): Promise<DailyTransitData> {
+    const newItem = this.generateCreateItemInput(item, actorId);
+    await this.ddb.put({
+      TableName: this.tableName,
+      Item: newItem,
+      // As this is evaluated after checking that both the PK and SK matches,
+      // we don't need to check that service_id is also unique.
+      ConditionExpression: 'attribute_not_exists(agency_id)',
+    });
+
+    return newItem;
   }
 }

--- a/libs/transit/src/daily-data/database.ts
+++ b/libs/transit/src/daily-data/database.ts
@@ -1,4 +1,9 @@
-import { Database, DatabaseCreateInput } from '@townhub-libs/core';
+import {
+  Database,
+  DatabaseCreateInput,
+  NotFoundException,
+} from '@townhub-libs/core';
+import { DateTime } from 'luxon';
 import { TransitDatabaseEnv } from '../constants';
 import { DailyTransitData } from './interfaces';
 
@@ -37,5 +42,22 @@ export class DailyDataDatabase extends Database<DailyTransitData> {
     });
 
     return newItem;
+  }
+
+  /**
+   * Get a daily transit data for a particular date and agency
+   * @param agencyId The agency to search for in
+   * @param date The date to check
+   */
+  async getByDate(agencyId: string, date: DateTime): Promise<DailyTransitData> {
+    const res = await this.ddb.get({
+      TableName: this.tableName,
+      Key: { agency_id: agencyId, date: date.toISODate() },
+    });
+    if (!res.Item)
+      throw new NotFoundException(
+        `Unable to find a daily transit data for agency ${agencyId} on ${date.toISODate()}`
+      );
+    return res.Item as DailyTransitData;
   }
 }

--- a/libs/transit/src/daily-data/database.ts
+++ b/libs/transit/src/daily-data/database.ts
@@ -1,0 +1,9 @@
+import { Database } from '@townhub-libs/core';
+import { TransitDatabaseEnv } from '../constants';
+import { DailyTransitData } from './interfaces';
+
+export class DailyDataDatabase extends Database<DailyTransitData> {
+  constructor() {
+    super(TransitDatabaseEnv.DailyData);
+  }
+}

--- a/libs/transit/src/daily-data/index.ts
+++ b/libs/transit/src/daily-data/index.ts
@@ -1,0 +1,2 @@
+export * from './database';
+export * from './interfaces';

--- a/libs/transit/src/daily-data/interfaces.ts
+++ b/libs/transit/src/daily-data/interfaces.ts
@@ -1,0 +1,44 @@
+import { ISODateString, ISOTimeString, TransitEntity } from '../interfaces';
+import { Route } from '../routes/interfaces';
+import { Stop } from '../stops/interfaces';
+import { Trip, TripDirection } from '../trips/interfaces';
+
+/**
+ * The timetable and trip data for a particular date. By saving these details,
+ * it means we can just generate this once and run the expensive queries once.
+ *
+ * All other calls will just be pulling the data out of the database.
+ */
+export interface DailyTransitData extends TransitEntity {
+  /** The date this data is for */
+  date: ISODateString;
+  /** List of routes used on that day */
+  routes: Route[];
+  /** List of trips used on that day */
+  trips: Trip[];
+  /** List of stops used on that day */
+  stops: Stop[];
+  /**
+   * A list of times that each trip starts on this date. This should be unique
+   * to each trip_id and time. Generated from each trip's frequencies array.
+   */
+  trip_start_times: { trip_id: string; time: ISOTimeString }[];
+  /**
+   * A list of times a bus arrives at a particular stop. This is a timetable
+   * that is generated so the frontend can display a particular stop's
+   * timetable to see when the next bus will arrive, etc.
+   */
+  stop_timetables: {
+    stop_id: string;
+    times: {
+      /** The route it is for */
+      route_id: string;
+      /** The direction of that route */
+      direction: TripDirection;
+      /** The arrival time of the bus */
+      arrival_time: ISOTimeString;
+      /** The departure time of the bus */
+      departure_time: ISOTimeString;
+    }[];
+  }[];
+}

--- a/libs/transit/src/index.ts
+++ b/libs/transit/src/index.ts
@@ -1,0 +1,1 @@
+export const test = 'asd';

--- a/libs/transit/src/index.ts
+++ b/libs/transit/src/index.ts
@@ -1,1 +1,7 @@
-export const test = 'asd';
+export * from './agencies';
+export * from './constants';
+export * from './daily-data';
+export * from './routes';
+export * from './services';
+export * from './stops';
+export * from './trips';

--- a/libs/transit/src/interfaces.ts
+++ b/libs/transit/src/interfaces.ts
@@ -3,8 +3,10 @@ import { BaseEntity } from '@townhub-libs/core';
 export type URL = string;
 export type LanguageCode = string;
 export type PhoneNumber = string;
-export type Timezone = string;
-export type Email = string;
+/** An IANA Timezone string */
+export type Timezone = `${string}/${string}`;
+/** An email type */
+export type Email = `${string}@${string}.${string}`;
 /** An ISO Date, formatted in YYYY-MM-DD */
 export type ISODateString = `${string}-${string}-${string}`;
 /** An ISO Time, formatted in HH:MM:SS */
@@ -17,51 +19,6 @@ export type NonNegativeInteger<T extends number = number> =
         : `${T}` extends `-${string}` | `${string}.${string}`
             ? never 
             : T;
-
-/**
- * Identifies a transit brand which is often synonymous with a transit agency.
- * Note that in some cases, such as when a single agency operates multiple
- * separate services, agencies and brands are distinct. This document uses the
- * term "agency" in place of "brand".
- */
-export interface Agency extends BaseEntity {
-  /** Full name of the transit agency. */
-  name: string;
-  /**
-   * URL of the transit agency.
-   */
-  url: URL;
-  /**
-   * Timezone where the transit agency is located. If multiple agencies are
-   * specified in the dataset, each must have the same timezone.
-   */
-  timezone: Timezone;
-  /**
-   * Primary language used by this transit agency. This field helps GTFS
-   * consumers choose capitalization rules and other language-specific settings
-   * for the dataset.
-   */
-  lang?: LanguageCode;
-  /**
-   * A voice telephone number for the specified agency. This field is a string
-   * value that presents the telephone number as typical for the agency's
-   * service area. It can and should contain punctuation marks to group the
-   * digits of the number. Dialable text (for example, TriMet's "503-238-RIDE")
-   * is permitted, but the field must not contain any other descriptive text.
-   */
-  phone?: PhoneNumber;
-  /**
-   * URL of a web page that allows a rider to purchase tickets or other fare
-   * instruments for that agency online.
-   */
-  fare_url?: URL;
-  /**
-   * Email address actively monitored by the agency’s customer service
-   * department. This email address should be a direct contact point where
-   * transit riders can reach a customer service representative at the agency.
-   */
-  email?: Email;
-}
 
 export interface TransitEntity extends BaseEntity {
   /** The agency this entity belongs to */

--- a/libs/transit/src/interfaces.ts
+++ b/libs/transit/src/interfaces.ts
@@ -1,0 +1,69 @@
+import { BaseEntity } from '@townhub-libs/core';
+
+export type URL = string;
+export type LanguageCode = string;
+export type PhoneNumber = string;
+export type Timezone = string;
+export type Email = string;
+/** An ISO Date, formatted in YYYY-MM-DD */
+export type ISODateString = `${string}-${string}-${string}`;
+/** An ISO Time, formatted in HH:MM:SS */
+export type ISOTimeString = `${string}:${string}:${string}`;
+
+ /** A non-negative integer value */
+export type NonNegativeInteger<T extends number = number> =
+    number extends T 
+        ? never 
+        : `${T}` extends `-${string}` | `${string}.${string}`
+            ? never 
+            : T;
+
+/**
+ * Identifies a transit brand which is often synonymous with a transit agency.
+ * Note that in some cases, such as when a single agency operates multiple
+ * separate services, agencies and brands are distinct. This document uses the
+ * term "agency" in place of "brand".
+ */
+export interface Agency extends BaseEntity {
+  /** Full name of the transit agency. */
+  name: string;
+  /**
+   * URL of the transit agency.
+   */
+  url: URL;
+  /**
+   * Timezone where the transit agency is located. If multiple agencies are
+   * specified in the dataset, each must have the same timezone.
+   */
+  timezone: Timezone;
+  /**
+   * Primary language used by this transit agency. This field helps GTFS
+   * consumers choose capitalization rules and other language-specific settings
+   * for the dataset.
+   */
+  lang?: LanguageCode;
+  /**
+   * A voice telephone number for the specified agency. This field is a string
+   * value that presents the telephone number as typical for the agency's
+   * service area. It can and should contain punctuation marks to group the
+   * digits of the number. Dialable text (for example, TriMet's "503-238-RIDE")
+   * is permitted, but the field must not contain any other descriptive text.
+   */
+  phone?: PhoneNumber;
+  /**
+   * URL of a web page that allows a rider to purchase tickets or other fare
+   * instruments for that agency online.
+   */
+  fare_url?: URL;
+  /**
+   * Email address actively monitored by the agency’s customer service
+   * department. This email address should be a direct contact point where
+   * transit riders can reach a customer service representative at the agency.
+   */
+  email?: Email;
+}
+
+export interface TransitEntity extends BaseEntity {
+  /** The agency this entity belongs to */
+  agency_id: string;
+}

--- a/libs/transit/src/routes/database.ts
+++ b/libs/transit/src/routes/database.ts
@@ -1,0 +1,9 @@
+import { Database } from '@townhub-libs/core';
+import { TransitDatabaseEnv } from '../constants';
+import { Route } from './interfaces';
+
+export class RoutesDatabase extends Database<Route> {
+  constructor() {
+    super(TransitDatabaseEnv.Routes);
+  }
+}

--- a/libs/transit/src/routes/index.ts
+++ b/libs/transit/src/routes/index.ts
@@ -1,0 +1,2 @@
+export * from './database';
+export * from './interfaces';

--- a/libs/transit/src/routes/interfaces.ts
+++ b/libs/transit/src/routes/interfaces.ts
@@ -1,0 +1,131 @@
+import { NonNegativeInteger, TransitEntity, URL } from '../interfaces';
+
+/** Color in Hex code, e.g. FFFFFF or 000000 */
+type Color = string;
+
+enum RouteType {
+  /**
+   * Tram, Streetcar, Light rail. Any light rail or street level system within
+   * a metropolitan area.
+   */
+  Tram = 0,
+  /**
+   * Subway, Metro. Any underground rail system within a metropolitan area.
+   */
+  Subway = 1,
+  /**
+   * Rail. Used for intercity or long-distance travel.
+   */
+  Rail = 2,
+  /**
+   * Bus. Used for short- and long-distance bus routes.
+   */
+  Bus = 3,
+  /**
+   * Ferry. Used for short- and long-distance boat service.
+   */
+  Ferry = 4,
+  /**
+   * Cable tram. Used for street-level rail cars where the cable runs beneath
+   * the vehicle, e.g., cable car in San Francisco.
+   */
+  CableTram = 5,
+  /**
+   * Aerial lift, suspended cable car (e.g., gondola lift, aerial tramway).
+   * Cable transport where cabins, cars, gondolas or open chairs are suspended
+   * by means of one or more cables.
+   */
+  AerialLift = 6,
+  /**
+   * Funicular. Any rail system designed for steep inclines.
+   */
+  Funicular = 7,
+  /**
+   * Trolleybus. Electric buses that draw power from overhead wires using poles.
+   */
+  Trolleybus = 11,
+  /**
+   * Monorail. Railway in which the track consists of a single rail or a beam.
+   */
+  Monorail = 12,
+}
+
+enum ContinuousBehaviour {
+  /** Continuous stopping pickup/drop-off. */
+  Continuous = 0,
+  /** No continuous stopping pickup/drop-off. */
+  None = 1,
+  /** Must phone agency to arrange continuous stopping pickup/drop-off. */
+  PhoneAgency = 2,
+  /** Must coordinate with driver to arrange continuous stopping pickup/drop-off. */
+  Coordinate = 3,
+}
+
+/**
+ * Identifies a route.
+ */
+export interface Route extends TransitEntity {
+  /**
+   * Short name of a route. This will often be a short, abstract identifier
+   * like "32", "100X", or "Green" that riders use to identify a route, but
+   * which doesn't give any indication of what places the route serves. Either
+   * route_short_name or route_long_name must be specified, or potentially both
+   * if appropriate.
+   */
+  route_short_name: string;
+  /**
+   * Full name of a route. This name is generally more descriptive than the
+   * route_short_name and often includes the route's destination or stop.
+   * Either route_short_name or route_long_name must be specified, or
+   * potentially both if appropriate.
+   */
+  route_long_name: string;
+  /**
+   * Description of a route that provides useful, quality information. Do not
+   * simply duplicate the name of the route.
+   *
+   * Example: "A" trains operate between Inwood-207 St, Manhattan and Far
+   * Rockaway-Mott Avenue, Queens at all times. Also from about 6AM until about
+   * midnight, additional "A" trains operate between Inwood-207 St and Lefferts
+   * Boulevard (trains typically alternate between Lefferts Blvd and Far Rockaway).
+   */
+  route_desc?: string;
+  /** Indicates the type of transportation used on a route. */
+  route_type: RouteType;
+  /**
+   * URL of a web page about the particular route. Should be different from the
+   * agency.agency_url value.
+   */
+  route_url?: URL;
+  /**
+   * Route color designation that matches public facing material. Defaults to
+   * white (FFFFFF) when omitted or left empty. The color difference between
+   * route_color and route_text_color should provide sufficient contrast when
+   * viewed on a black and white screen.
+   */
+  route_color?: Color;
+  /**
+   * Legible color to use for text drawn against a background of route_color.
+   * Defaults to black (000000) when omitted or left empty. The color
+   * difference between route_color and route_text_color should provide
+   * sufficient contrast when viewed on a black and white screen.
+   */
+  route_text_color?: Color;
+  /**
+   * Orders the routes in a way which is ideal for presentation to customers.
+   * Routes with smaller route_sort_order values should be displayed first.
+   */
+  route_sort_order?: NonNegativeInteger;
+  /**
+   * Indicates that the rider can board the transit vehicle at any point along
+   * the vehicle’s travel path as described by shapes.txt, on every trip of the
+   * route.
+   */
+  continuous_pickup?: ContinuousBehaviour;
+  /**
+   * Indicates that the rider can alight from the transit vehicle at any point
+   * along the vehicle’s travel path as described by shapes.txt, on every trip
+   * of the route.
+   */
+  continuous_drop_off?: ContinuousBehaviour;
+}

--- a/libs/transit/src/services/database.ts
+++ b/libs/transit/src/services/database.ts
@@ -1,0 +1,9 @@
+import { Database } from '@townhub-libs/core';
+import { TransitDatabaseEnv } from '../constants';
+import { Service } from './interfaces';
+
+export class ServicesDatabase extends Database<Service> {
+  constructor() {
+    super(TransitDatabaseEnv.Services);
+  }
+}

--- a/libs/transit/src/services/database.ts
+++ b/libs/transit/src/services/database.ts
@@ -21,10 +21,12 @@ export class ServicesDatabase extends Database<Service> {
     endDate: DateTime
   ): Promise<Service[]> {
     const res = await this.query({
-      IndexName: DDB_INDEX_NAMES.SERVICES.AGENCY_ID_START_DATE,
+      IndexName: DDB_INDEX_NAMES.SERVICES.AGENCY_ID_END_DATE,
+      // Find all that is in the future first
       KeyConditionExpression:
-        'agency_id = :agency_id AND start_date <= :query_end_date',
-      FilterExpression: 'end_date >= :query_start_date',
+        'agency_id = :agency_id AND end_date >= :query_start_date',
+      // And then filter to make sure the start date is before the end date
+      FilterExpression: 'start_date <= :query_end_date',
       ExpressionAttributeValues: {
         ':agency_id': agencyId,
         ':query_start_date': startDate.toISODate(),

--- a/libs/transit/src/services/database.ts
+++ b/libs/transit/src/services/database.ts
@@ -1,9 +1,37 @@
 import { Database } from '@townhub-libs/core';
-import { TransitDatabaseEnv } from '../constants';
+import { DateTime } from 'luxon';
+import { DDB_INDEX_NAMES, TransitDatabaseEnv } from '../constants';
 import { Service } from './interfaces';
 
 export class ServicesDatabase extends Database<Service> {
   constructor() {
     super(TransitDatabaseEnv.Services);
+  }
+
+  /**
+   * Get a list of all services that is occuring during a given time range
+   * @param agencyId The agency the service belongs to
+   * @param startDate The start date to search for
+   * @param endDate The end date to search for
+   * @returns List of services
+   */
+  async getServicesBetweenRange(
+    agencyId: string,
+    startDate: DateTime,
+    endDate: DateTime
+  ): Promise<Service[]> {
+    const res = await this.query({
+      IndexName: DDB_INDEX_NAMES.SERVICES.AGENCY_ID_START_DATE,
+      KeyConditionExpression:
+        'agency_id = :agency_id AND start_date <= :query_end_date',
+      FilterExpression: 'end_date >= :query_start_date',
+      ExpressionAttributeValues: {
+        ':agency_id': agencyId,
+        ':query_start_date': startDate.toISODate(),
+        ':query_end_date': endDate.toISODate(),
+      },
+    });
+
+    return res;
   }
 }

--- a/libs/transit/src/services/index.ts
+++ b/libs/transit/src/services/index.ts
@@ -1,0 +1,2 @@
+export * from './database';
+export * from './interfaces';

--- a/libs/transit/src/services/interfaces.ts
+++ b/libs/transit/src/services/interfaces.ts
@@ -1,0 +1,42 @@
+import { ISODateString, TransitEntity } from '../interfaces';
+
+enum ServiceAvailability {
+  NotAvailable = 0,
+  Available = 1,
+}
+
+enum ExceptionType {
+  ServiceAdded = 1,
+  ServiceRemoved = 2,
+}
+
+export interface Service extends TransitEntity {
+  /** Indicates whether the service operates on this day of the week */
+  monday: ServiceAvailability;
+  /** Indicates whether the service operates on this day of the week */
+  tuesday: ServiceAvailability;
+  /** Indicates whether the service operates on this day of the week */
+  wednesday: ServiceAvailability;
+  /** Indicates whether the service operates on this day of the week */
+  thursday: ServiceAvailability;
+  /** Indicates whether the service operates on this day of the week */
+  friday: ServiceAvailability;
+  /** Indicates whether the service operates on this day of the week */
+  saturday: ServiceAvailability;
+  /** Indicates whether the service operates on this day of the week */
+  sunday: ServiceAvailability;
+  /** Start service day for the service interval. */
+  start_date: ISODateString;
+  /**
+   * End service day for the service interval. This service day is included in
+   * the interval.
+   */
+  end_date: ISODateString;
+  /** List of exceptions to the service */
+  exceptions: {
+    /** Date when service exception occurs. */
+    date: ISODateString;
+    /** Indicates whether service is available on the date specified in the date field.  */
+    exception_type: ExceptionType;
+  }[];
+}

--- a/libs/transit/src/stops/database.ts
+++ b/libs/transit/src/stops/database.ts
@@ -1,0 +1,9 @@
+import { Database } from '@townhub-libs/core';
+import { TransitDatabaseEnv } from '../constants';
+import { Stop } from './interfaces';
+
+export class StopsDatabase extends Database<Stop> {
+  constructor() {
+    super(TransitDatabaseEnv.Stops);
+  }
+}

--- a/libs/transit/src/stops/index.ts
+++ b/libs/transit/src/stops/index.ts
@@ -1,0 +1,2 @@
+export * from './database';
+export * from './interfaces';

--- a/libs/transit/src/stops/interfaces.ts
+++ b/libs/transit/src/stops/interfaces.ts
@@ -1,0 +1,197 @@
+import { BaseEntity } from '@townhub-libs/core';
+import { Timezone, TransitEntity } from '../interfaces';
+
+type Latitude = number;
+type Longitude = number;
+
+enum StopLocationType {
+  /**
+   * A location where passengers board or disembark from a transit vehicle. Is
+   * called a platform when defined within a parent_station.
+   */
+  Stop = 0,
+  /**
+   * A physical structure or area that contains one or more platform.
+   */
+  Station = 1,
+  /**
+   * A location where passengers can enter or exit a station from the street.
+   * If an entrance/exit belongs to multiple stations, it can be linked by
+   * pathways to both, but the data provider must pick one of them as parent.
+   */
+  EntranceExit = 2,
+  /**
+   * A location within a station, not matching any other location_type, which
+   * can be used to link together pathways define in pathways.txt.
+   */
+  GenericNode = 3,
+  /**
+   * A specific location on a platform, where passengers can board and/or
+   * alight vehicles.
+   */
+  BoardingArea = 4,
+}
+
+/**
+ * Indicates whether wheelchair boardings are possible from the location. Valid
+ * options are:
+ *
+ * For parentless stops:
+ * * 0 or empty - No accessibility information for the stop.
+ * * 1 - Some vehicles at this stop can be boarded by a rider in a wheelchair.
+ * * 2 - Wheelchair boarding is not possible at this stop.
+ *
+ * For child stops:
+ * * 0 or empty - Stop will inherit its wheelchair_boarding behavior from the
+ *   parent station, if specified in the parent.
+ * * 1 - There exists some accessible path from outside the station to the
+ *   specific stop/platform.
+ * * 2 - There exists no accessible path from outside the station to the
+ *   specific stop/platform.
+ *
+ * For station entrances/exits:
+ * * 0 or empty - Station entrance will inherit its wheelchair_boarding
+ *   behavior from the parent station, if specified for the parent.
+ * * 1 - Station entrance is wheelchair accessible.
+ * * 2 - No accessible path from station entrance to stops/platforms.
+ */
+enum StopWheelchairBoarding {
+  Inherit = 0,
+  Some = 1,
+  None = 2,
+}
+
+/**
+ * Identifies a stop, station, or station entrance.
+ *
+ * The term "station entrance" refers to both station entrances and station
+ * exits. Stops, stations or station entrances are collectively referred to as
+ * locations. Multiple routes may use the same stop.
+ */
+export interface Stop extends TransitEntity {
+  /**
+   * Short text or a number that identifies the location for riders. These
+   * codes are often used in phone-based transit information systems or printed
+   * on signage to make it easier for riders to get information for a
+   * particular location. The code can be the same as id if it is
+   * public facing. This field should be left empty for locations without a
+   * code presented to riders.
+   */
+  code?: string;
+  /**
+   * Name of the location. Use a name that people will understand in the local
+   * and tourist vernacular.
+   *
+   * When the location is a boarding area (location_type=4), the name
+   * should contains the name of the boarding area as displayed by the agency.
+   * It could be just one letter (like on some European intercity railway
+   * stations), or text like “Wheelchair boarding area” (NYC’s Subway) or “Head
+   * of short trains” (Paris’ RER).
+   *
+   * Conditionally Required:
+   *  * Required for locations which are stops (location_type=0), stations
+   *    (location_type=1) or entrances/exits (location_type=2).
+   *  * Optional for locations which are generic nodes (location_type=3) or
+   *    boarding areas (location_type=4).
+   */
+  name: string;
+  /**
+   * Readable version of the name. See "Text-to-speech field" in the Term
+   * Definitions for more.
+   */
+  tts_name?: string;
+  /**
+   * Description of the location that provides useful, quality information. Do
+   * not simply duplicate the name of the location.
+   */
+  desc?: Text;
+  /**
+   * 	Latitude of the location.
+   *
+   * For stops/platforms (location_type=0) and boarding area (location_type=4),
+   * the coordinates must be the ones of the bus pole — if exists — and
+   * otherwise of where the travelers are boarding the vehicle (on the sidewalk
+   * or the platform, and not on the roadway or the track where the vehicle stops).
+   *
+   * Conditionally Required:
+   * * Required for locations which are stops (location_type=0), stations
+   *   (location_type=1) or entrances/exits (location_type=2).
+   * * Optional for locations which are generic nodes (location_type=3) or
+   *   boarding areas (location_type=4).
+   */
+  lat?: Latitude;
+  /**
+   * 	Longitude of the location.
+   *
+   * For stops/platforms (location_type=0) and boarding area (location_type=4),
+   * the coordinates must be the ones of the bus pole — if exists — and
+   * otherwise of where the travelers are boarding the vehicle (on the sidewalk
+   * or the platform, and not on the roadway or the track where the vehicle stops).
+   *
+   * Conditionally Required:
+   * * Required for locations which are stops (location_type=0), stations
+   *   (location_type=1) or entrances/exits (location_type=2).
+   * * Optional for locations which are generic nodes (location_type=3) or
+   *   boarding areas (location_type=4).
+   */
+  lon?: Longitude;
+  /**
+   * Identifies the fare zone for a stop. This field is required if providing
+   * fare information using fare_rules.txt, otherwise it is optional. If this
+   * record represents a station or station entrance, the zone_id is ignored.
+   */
+  zone_id?: string;
+  /**
+   * URL of a web page about the location. This should be different from the
+   * agency.agency_url and the routes.route_url field values.
+   */
+  url?: URL;
+  /** Type of the location */
+  location_type?: StopLocationType;
+  /**
+   * Defines hierarchy between the different locations defined in stops.txt. It
+   * contains the ID of the parent location, as followed:
+   * * Stop/platform (location_type=0): the parent_station field contains the
+   *   ID of a station.
+   * * Station (location_type=1): this field must be empty.
+   * * Entrance/exit (location_type=2) or generic node (location_type=3): the
+   *   parent_station field contains the ID of a station (location_type=1)
+   * * Boarding Area (location_type=4): the parent_station field contains ID of
+   *   a platform.
+   *
+   * Conditionally Required:
+   * * Required for locations which are entrances (location_type=2), generic
+   *   nodes (location_type=3) or boarding areas (location_type=4).
+   * * Optional for stops/platforms (location_type=0).
+   * * Forbidden for stations (location_type=1).
+   */
+  parent_station?: string;
+  /**
+   * Timezone of the location. If the location has a parent station, it
+   * inherits the parent station’s timezone instead of applying its own.
+   * Stations and parentless stops with empty timezone inherit the
+   * timezone specified by agency.agency_timezone. If timezone values are
+   * provided, the times in times.txt should be entered as the time since
+   * midnight in the timezone specified by agency.agency_timezone. This ensures
+   * that the time values in a trip always increase over the course of a trip,
+   * regardless of which timezones the trip crosses.
+   */
+  timezone?: Timezone;
+  /**
+   * Indicates whether wheelchair boardings are possible from the location.
+   */
+  wheelchair_boarding?: StopWheelchairBoarding;
+  /**
+   * Level of the location. The same level can be used by multiple unlinked
+   * stations.
+   */
+  level_id?: string;
+  /**
+   * Platform identifier for a platform stop (a stop belonging to a station).
+   * This should be just the platform identifier (eg. "G" or "3"). Words like
+   * “platform” or "track" (or the feed’s language-specific equivalent) should
+   * not be included. This allows feed consumers to more easily
+   * internationalize and localize the platform identifier into other languages.
+   */
+  platform_code?: string;
+}

--- a/libs/transit/src/trips/database.ts
+++ b/libs/transit/src/trips/database.ts
@@ -1,0 +1,9 @@
+import { Database } from '@townhub-libs/core';
+import { TransitDatabaseEnv } from '../constants';
+import { Trip } from './interfaces';
+
+export class TripsDatabase extends Database<Trip> {
+  constructor() {
+    super(TransitDatabaseEnv.Trips);
+  }
+}

--- a/libs/transit/src/trips/database.ts
+++ b/libs/transit/src/trips/database.ts
@@ -2,11 +2,6 @@ import { Database, DatabaseCreateInput } from '@townhub-libs/core';
 import { DDB_INDEX_NAMES, TransitDatabaseEnv } from '../constants';
 import { Trip } from './interfaces';
 
-type TripsDatabaseCreateInput = Omit<
-  DatabaseCreateInput<Trip>,
-  'route_id_service_id'
->;
-
 /**
  * The Trips Table should be setup with the following details:
  * * PartitionKey: `route_id`
@@ -27,7 +22,10 @@ export class TripsDatabase extends Database<Trip> {
    * @param actorId The user performing the create
    * @returns The trip that was created
    */
-  async create(item: TripsDatabaseCreateInput, actorId: string): Promise<Trip> {
+  async create(
+    item: DatabaseCreateInput<Trip>,
+    actorId: string
+  ): Promise<Trip> {
     const newItem = this.generateCreateItemInput(item, actorId);
     await this.ddb.put({
       TableName: this.tableName,

--- a/libs/transit/src/trips/database.ts
+++ b/libs/transit/src/trips/database.ts
@@ -1,9 +1,83 @@
-import { Database } from '@townhub-libs/core';
-import { TransitDatabaseEnv } from '../constants';
+import { Database, DatabaseCreateInput } from '@townhub-libs/core';
+import { DDB_INDEX_NAMES, TransitDatabaseEnv } from '../constants';
 import { Trip } from './interfaces';
 
+type TripsDatabaseCreateInput = Omit<
+  DatabaseCreateInput<Trip>,
+  'route_id_service_id'
+>;
 export class TripsDatabase extends Database<Trip> {
   constructor() {
     super(TransitDatabaseEnv.Trips);
+  }
+
+  /**
+   * When creating a new trip, we want to make sure that the particular
+   * service_id and route_id combination does not already exist in the database
+   * @param item The new trip to create
+   * @returns The trip that was created
+   */
+  async create(item: TripsDatabaseCreateInput): Promise<Trip> {
+    const newItem = this.generateCreateItemInput(item);
+    await this.ddb.put({
+      TableName: this.tableName,
+      Item: newItem,
+      ConditionExpression:
+        'attribute_not_exists(id) AND attribute_not_exists(route_id_service_id)',
+    });
+
+    return newItem;
+  }
+
+  /**
+   * Get all trips that exist for a list of services
+   * @param agencyId The agency the trips belong to
+   * @param serviceIds The list of services to look for
+   * @returns The list of trips
+   */
+  async getAllTripsForServices(
+    agencyId: string,
+    serviceIds: string[]
+  ): Promise<Trip[]> {
+    // Sort the serviceIds so that we can narrow down our search based on the UUID
+    const sortedServiceIds = serviceIds.sort();
+
+    // Create the object for the values
+    const serviceIdValues: Record<string, string> = {};
+    sortedServiceIds.forEach((val, index) => {
+      serviceIdValues[`:service${index}`] = val;
+    });
+
+    // Run the Query
+    const res = await this.query({
+      IndexName: DDB_INDEX_NAMES.TRIPS.AGENCY_ID_SERVICE_ID,
+      KeyConditionExpression:
+        'agency_id = :agency_id AND service_id BETWEEN :first_service_id AND :last_service_id',
+      FilterExpression: `service_id IN (${Object.keys(serviceIdValues).join(
+        ', '
+      )})`,
+      ExpressionAttributeValues: {
+        ':agency_id': agencyId,
+        ':first_service_id': sortedServiceIds[0],
+        ':last_service_id': sortedServiceIds[sortedServiceIds.length - 1],
+        ...serviceIdValues,
+      },
+    });
+
+    return res;
+  }
+
+  /**
+   * We need to automaticall add the route_id and service_id combination so
+   * that it's always correct
+   * @param item The newly created item
+   * @returns A trip that can be used for the create call
+   */
+  protected generateCreateItemInput(item: TripsDatabaseCreateInput): Trip {
+    return super.generateCreateItemInput({
+      ...item,
+      // Set the combination id
+      route_id_service_id: `${item.route_id}|${item.service_id}`,
+    });
   }
 }

--- a/libs/transit/src/trips/index.ts
+++ b/libs/transit/src/trips/index.ts
@@ -1,0 +1,2 @@
+export * from './database';
+export * from './interfaces';

--- a/libs/transit/src/trips/interfaces.ts
+++ b/libs/transit/src/trips/interfaces.ts
@@ -124,10 +124,14 @@ interface TripFrequency {
 export interface Trip extends TransitEntity {
   /** Identifies a route. */
   route_id: string;
+  /** Identifies a set of dates when service is available */
+  service_id: string;
   /**
-   * Identifies a set of dates when service is available for one or more routes
+   * A combination key merging the route_id and the service_id so that we can
+   * query for a combination route and service easily. Should be in the format
+   * of `[route_id]|[service_id]` (a pipe in between).
    */
-  service_ids: string[];
+  route_id_service_id: `${string}|${string}`;
   /**
    * An ordered list of stops that is included in this trip, the index in the
    * array, indicates the sequence.

--- a/libs/transit/src/trips/interfaces.ts
+++ b/libs/transit/src/trips/interfaces.ts
@@ -127,12 +127,6 @@ export interface Trip extends TransitEntity {
   /** Identifies a set of dates when service is available */
   service_id: string;
   /**
-   * A combination key merging the route_id and the service_id so that we can
-   * query for a combination route and service easily. Should be in the format
-   * of `[route_id]|[service_id]` (a pipe in between).
-   */
-  route_id_service_id: `${string}|${string}`;
-  /**
    * An ordered list of stops that is included in this trip, the index in the
    * array, indicates the sequence.
    */

--- a/libs/transit/src/trips/interfaces.ts
+++ b/libs/transit/src/trips/interfaces.ts
@@ -1,0 +1,173 @@
+import {
+  ISODateString,
+  ISOTimeString,
+  NonNegativeInteger,
+  TransitEntity,
+} from '../interfaces';
+
+enum TripDirection {
+  Outbound = 0,
+  Inbound = 1,
+}
+
+enum TripWheelchairAccessible {
+  /**
+   * No accessibility information for the trip.
+   */
+  NoInformation = 0,
+  /**
+   * Vehicle being used on this particular trip can accommodate at least one rider in a wheelchair.
+   */
+  Available = 1,
+  /**
+   * No riders in wheelchairs can be accommodated on this trip.
+   */
+  NotAccesible = 2,
+}
+
+enum TripBikesAllowed {
+  /**
+   * No bike information for the trip.
+   */
+  NoInformation = 0,
+  /**
+   * Vehicle being used on this particular trip can accommodate at least one bicycle.
+   */
+  Allowed = 1,
+  /**
+   * No bicycles are allowed on this trip.
+   */
+  NotAllowed = 2,
+}
+
+interface TripStop {
+  /**
+   * Identifies the serviced stop. All stops serviced during a trip must have
+   * a record in stop_times.txt. Referenced locations must be stops, not
+   * stations or station entrances. A stop may be serviced multiple times in
+   * the same trip, and multiple trips and routes may service the same stop.
+   */
+  stop_id: string;
+  /**
+   * Arrival time at a specific stop for a specific trip on a route. If there
+   * are not separate times for arrival and departure at a stop, enter the
+   * same value for arrival_time and departure_time. For times occurring after
+   * midnight on the service day, enter the time as a value greater than
+   * 24:00:00 in HH:MM:SS local time for the day on which the trip schedule
+   * begins.
+   *
+   * Scheduled stops where the vehicle strictly adheres to the specified arrival
+   * and departure times are timepoints. If this stop is not a timepoint, it
+   * is recommended to provide an estimated or interpolated time. If this is
+   * not available, arrival_time can be left empty. Further, indicate that
+   * interpolated times are provided with timepoint=0. If interpolated times
+   * are indicated with timepoint=0, then time points must be indicated with
+   * timepoint=1. Provide arrival times for all stops that are time points.
+   * An arrival time must be specified for the first and the last stop in a
+   * trip.
+   */
+  arrival_time: ISOTimeString;
+  /**
+   * Departure time from a specific stop for a specific trip on a route. For
+   * times occurring after midnight on the service day, enter the time as a
+   * value greater than 24:00:00 in HH:MM:SS local time for the day on which
+   * the trip schedule begins. If there are not separate times for arrival
+   * and departure at a stop, enter the same value for arrival_time and
+   * departure_time. See the arrival_time description for more details about
+   * using timepoints correctly.
+   *
+   * The departure_time field should specify time values whenever possible,
+   * including non-binding estimated or interpolated times between timepoints.
+   */
+  departure_time: ISOTimeString;
+}
+
+enum TripFrequencyType {
+  /**
+   * Frequency-based service (exact_times=0) in which service does not follow a
+   * fixed schedule throughout the day. Instead, operators attempt to strictly
+   * maintain predetermined headways for trips.
+   */
+  Frequency = 0,
+  /**
+   * Schedule-based trips with the exact same headway throughout the day. In
+   * this case the end_time value must be greater than the last desired trip
+   * start_time but less than the last desired trip start_time + headway_secs.
+   *
+   * A compressed representation of schedule-based service (exact_times=1) that
+   * has the exact same headway for trips over specified time period(s). In
+   * schedule-based service operators try to strictly adhere to a schedule.
+   */
+  Schedule = 1,
+}
+
+interface TripFrequency {
+  /**
+   * Time at which the first vehicle departs from the first stop of the trip
+   * with the specified headway.
+   */
+  start_time: ISOTimeString;
+  /**
+   * Time at which service changes to a different headway (or ceases) at the
+   * first stop in the trip.
+   */
+  end_time: ISOTimeString;
+  /**
+   * Time, in seconds, between departures from the same stop (headway) for the
+   * trip, during the time interval specified by start_time and end_time.
+   * Multiple headways for the same trip are allowed, but may not overlap. New
+   * headways may start at the exact time the previous headway ends.
+   */
+  headway_secs: NonNegativeInteger;
+  exact_times: TripFrequencyType;
+}
+
+export interface Trip extends TransitEntity {
+  /** Identifies a route. */
+  route_id: string;
+  /**
+   * Identifies a set of dates when service is available for one or more routes
+   */
+  service_ids: string[];
+  /**
+   * An ordered list of stops that is included in this trip, the index in the
+   * array, indicates the sequence.
+   */
+  stops: TripStop[];
+  /**
+   * The frequencies that the trip occurs throughout the day
+   */
+  frequencies: TripFrequencyType[];
+  /**
+   * Text that appears on signage identifying the trip's destination to riders.
+   * Use this field to distinguish between different patterns of service on the
+   * same route. If the headsign changes during a trip, trip_headsign can be
+   * overridden by specifying values for the stop_times.stop_headsign.
+   */
+  trip_headsign?: string;
+  /**
+   * Public facing text used to identify the trip to riders, for instance, to
+   * identify train numbers for commuter rail trips. If riders do not commonly
+   * rely on trip names, leave this field empty. A trip_short_name value, if
+   * provided, should uniquely identify a trip within a service day; it should
+   * not be used for destination names or limited/express designations.
+   */
+  trip_short_name?: string;
+  /**
+   * Indicates the direction of travel for a trip. This field is not used in
+   * routing; it provides a way to separate trips by direction when publishing
+   * time tables.
+   *
+   * Example: The trip_headsign and direction_id fields could be used together
+   * to assign a name to travel in each direction for a set of trips. A
+   * trips.txt file could contain these records for use in time tables:
+   * * trip_id,...,trip_headsign,direction_id
+   * * 1234,...,Airport,0
+   * * 1505,...,Downtown,1
+   */
+  direction_id?: TripDirection;
+  /** Indicates wheelchair accessibility. */
+  wheelchair_accessible?: TripWheelchairAccessible;
+  /** Indicates whether bikes are allowed */
+  bikes_allowed?: TripBikesAllowed;
+}

--- a/libs/transit/src/trips/interfaces.ts
+++ b/libs/transit/src/trips/interfaces.ts
@@ -1,11 +1,10 @@
 import {
-  ISODateString,
   ISOTimeString,
   NonNegativeInteger,
   TransitEntity,
 } from '../interfaces';
 
-enum TripDirection {
+export enum TripDirection {
   Outbound = 0,
   Inbound = 1,
 }
@@ -137,7 +136,7 @@ export interface Trip extends TransitEntity {
   /**
    * The frequencies that the trip occurs throughout the day
    */
-  frequencies: TripFrequencyType[];
+  frequencies: TripFrequency[];
   /**
    * Text that appears on signage identifying the trip's destination to riders.
    * Use this field to distinguish between different patterns of service on the

--- a/libs/transit/tsconfig.build.json
+++ b/libs/transit/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "."
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
The shuttles module does not handle all use cases so this is adjusting it to be more inline with a GTFS-based system, albeit modified to suit a NoSQL based system so we can use DynamoDB.

Part of this is renaming it to be a `transit` module instead of just `shuttles` as it does allow for other transit systems like trains and subways in the future.

This resolves #40 